### PR TITLE
Lock versions of jQuery and QUnit in tests

### DIFF
--- a/test/units.html
+++ b/test/units.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 	<head>
-		<script src="http://code.jquery.com/jquery-latest.js"></script>
-		<link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen" />
-		<script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js"></script>
+		<script src="http://code.jquery.com/jquery-1.8.0.min.js"></script>
+		<link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.9.0.css" type="text/css" media="screen" />
+		<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.9.0.js"></script>
 		<script type="text/javascript" src="../javascript/emulator.js"></script>
 		<script type="text/javascript" src="../javascript/keyboard.js"></script>
 		<script type="text/javascript" src="../javascript/clock.js"></script>


### PR DESCRIPTION
The URL to QUnit used in the tests returns a 404 resulting in the tests not running, this replaces it with the CDN version of QUnit to 1.9.0. It also locks jQuery to version 1.8.0.
